### PR TITLE
Fix Tx Power parsing after merge resolution

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -80,7 +80,7 @@ def parse_bluetoothctl_info(text: str) -> Dict[str, Any]:
                 parsed["rssi"] = int(val)
             except ValueError:
                 parsed["rssi"] = None
-        elif k == "txpower":
+        elif k == "tx_power":
             try:
                 parsed["tx_power"] = int(val)
             except ValueError:

--- a/backend/main_enhanced.py
+++ b/backend/main_enhanced.py
@@ -155,7 +155,7 @@ def parse_bluetoothctl_info(text: str) -> Dict[str, Any]:
                 parsed["rssi"] = int(val)
             except ValueError:
                 parsed["rssi"] = None
-        elif k == "txpower":
+        elif k == "tx_power":
             try:
                 parsed["tx_power"] = int(val)
             except ValueError:


### PR DESCRIPTION
## Summary
- correct the bluetoothctl info parser to map the Tx Power field using the normalized key
- apply the same fix to both the lightweight and enhanced FastAPI entrypoints so parsed data is consistent

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68ceadef0d18832cbdd008e126a4c703